### PR TITLE
Add ShellCheck to workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -26,6 +26,10 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@v4
+    - name: Install ShellCheck
+      run: sudo apt-get update && sudo apt-get install -y shellcheck
+    - name: ShellCheck
+      run: shellcheck entrypoint.sh setup_universal.sh
     - name: Log in to ghcr.io
       uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
       with:


### PR DESCRIPTION
## Summary
- run ShellCheck in CI on `entrypoint.sh` and `setup_universal.sh`

## Testing
- `apt-get update`
- `apt-get install -y shellcheck` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68634c9e31508332b75380d9a206b84d